### PR TITLE
End the day at 6am EST / 3am PST

### DIFF
--- a/lib/threadbot.ex
+++ b/lib/threadbot.ex
@@ -57,7 +57,7 @@ defmodule BotConsumer do
     if !msg.author.bot && (msg.embeds != [] || msg.attachments != []) do
       case :ets.lookup(:channels, msg.channel_id) do
         [{_, true}] ->
-          start_time = ~N[2022-12-21 05:00:00.000000Z]
+          start_time = ~N[2022-12-21 11:00:00.000000Z]
           current_time = NaiveDateTime.utc_now()
           diff = NaiveDateTime.diff(current_time, start_time) 
                  |> IO.inspect()


### PR DESCRIPTION
Currently a new day begins at 12am eastern, but some people are on pacific time so it starts at 9pm the previous day for them, and also the day for most young people ends well after 12am. I propose starting a new day at 6am eastern / 3am pacific. I don’t imagine anyone is going to be awake around that time, so it will feel less weird for most people.